### PR TITLE
autofix/final-hardening-and-e2e

### DIFF
--- a/.github/workflows/agent-engineer.yml
+++ b/.github/workflows/agent-engineer.yml
@@ -84,6 +84,8 @@ PY
             - Automatischer Engineer-Run (Ack-Datei)
             - Falls „Deterministic/Gate“ im Titel: `config/policies.yaml`
             - Falls Parsing/Normalize: Smoke-Test scaffold
+            Closes #${{ env.ISSUE_NUMBER }}
           labels: agent:engineer, ready-for-review
           signoff: true
           delete-branch: true
+

--- a/.github/workflows/agent-growth.yml
+++ b/.github/workflows/agent-growth.yml
@@ -66,6 +66,8 @@ MD
             - `drafts/outreach/template.md` (idempotent)
             - `drafts/README.md` (idempotent)
             - Ack-Datei für Nachvollziehbarkeit
+            Closes #${{ env.ISSUE_NUMBER }}
           labels: agent:growth, ready-for-review
           signoff: true
           delete-branch: true
+

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -3,6 +3,12 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
@@ -17,32 +23,20 @@ jobs:
       - name: Run smoke eval script
         run: |
           python scripts/check_eval.py
-      - name: Set commit status 'eval' (success)
-        if: ${{ success() && github.event_name == 'pull_request' }}
+      - name: Set commit status 'eval'
+        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           script: |
+            const state = '${{ job.status }}' === 'success' ? 'success' : 'failure';
+            const description = state === 'success' ? 'Smoke passed' : 'Smoke failed';
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,
-              state: 'success',
+              state,
               context: 'eval',
-              description: 'Smoke passed',
+              description,
               target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
             });
 
-      - name: Set commit status 'eval' (failure)
-        if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'failure',
-              context: 'eval',
-              description: 'Smoke failed',
-              target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
-            });

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -17,5 +17,7 @@ jobs:
         uses: micnncim/action-label-syncer@v1
         with:
           manifest: .github/labels.yml
+          repository: ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -2,11 +2,22 @@ name: Orchestrator
 
 on:
   issues:
-    types: [opened, labeled, edited]   # <— opened hinzugefügt
+    types: [opened, labeled, edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue #
+        required: true
+      issue_title:
+        description: Issue title
+        required: true
+      issue_body:
+        description: Issue body
+        required: false
 
 concurrency:
-  group: orchestrate-${{ github.event.issue.number }}
-  cancel-in-progress: true             # <— doppelte Läufe abbrechen
+  group: orchestrate-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -16,9 +27,12 @@ permissions:
 
 jobs:
   orchestrate:
-    # nur laufen, wenn das Issue tatsächlich das Label trägt
-    if: contains(github.event.issue.labels.*.name, 'task:agent')
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, 'task:agent') }}
     runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      ISSUE_TITLE:  ${{ github.event.issue.title  || inputs.issue_title  || '' }}
+      ISSUE_BODY:   ${{ github.event.issue.body   || inputs.issue_body   || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -30,6 +44,9 @@ jobs:
         id: orch
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
+          MANUAL_ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
+          MANUAL_ISSUE_TITLE:  ${{ env.ISSUE_TITLE }}
+          MANUAL_ISSUE_BODY:   ${{ env.ISSUE_BODY }}
         run: python scripts/orchestrate.py
 
       - name: Commit plan files
@@ -37,19 +54,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add reports/board/ || true
-          git commit -m "chore(plan): add/update plan for #${{ github.event.issue.number }}" || echo "No changes"
+          git commit -m "chore(plan): add/update plan for #${ISSUE_NUMBER}" || echo "No changes"
           git push || true
 
       - name: Comment plan link on issue
         uses: actions/github-script@v7
+        env:
+          PLAN_PATH: ${{ steps.orch.outputs.plan_path }}
+          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         with:
           script: |
-            const issue_number = context.payload.issue.number;
+            const issue_number = parseInt(process.env.ISSUE_NUMBER,10);
             const planPath = process.env.PLAN_PATH || "(kein Plan gefunden)";
             const body = `Plan erzeugt/aktualisiert: \`${planPath}\``;
             await github.rest.issues.createComment({ ...context.repo, issue_number, body });
-        env:
-          PLAN_PATH: ${{ steps.orch.outputs.plan_path }}
 
 
       - name: Trigger agents (repo_dispatch + workflow_dispatch + check)
@@ -57,10 +75,12 @@ jobs:
         uses: actions/github-script@v7
         env:
           PLAN_PATH: ${{ steps.orch.outputs.plan_path }}
+          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
+          ISSUE_TITLE: ${{ env.ISSUE_TITLE }}
         with:
           script: |
             const {owner, repo} = context.repo;
-            const issue = context.payload.issue;
+            const issue = { number: parseInt(process.env.ISSUE_NUMBER,10), title: process.env.ISSUE_TITLE || '' };
             const title = (issue.title || "").toLowerCase();
             const ref   = context.payload.repository?.default_branch || "main";
 
@@ -163,9 +183,9 @@ MD
 Deterministische Vorlagen. Keine PII/Secrets. Änderungen per PR.
 MD
           fi
-          FILE="reports/agent_runs/growth-fallback-issue-${{ github.event.issue.number }}.md"
+          FILE="reports/agent_runs/growth-fallback-issue-${ISSUE_NUMBER}.md"
           if [ ! -f "$FILE" ]; then
-            echo "# Growth fallback for Issue #${{ github.event.issue.number }}" > "$FILE"
+            echo "# Growth fallback for Issue #${ISSUE_NUMBER}" > "$FILE"
             echo "Plan: ${{ steps.orch.outputs.plan_path }}" >> "$FILE"
           fi
 
@@ -173,12 +193,13 @@ MD
         if: ${{ steps.dispatch.outputs.NEED_FALLBACK_GROWTH == 'true' }}
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "feat(growth): fallback outreach drafts for issue #${{ github.event.issue.number }}"
-          branch: "agent/growth/issue-${{ github.event.issue.number }}"
-          title: "Growth: Fallback-Drafts für #${{ github.event.issue.number }}"
+          commit-message: "feat(growth): fallback outreach drafts for issue #${{ env.ISSUE_NUMBER }}"
+          branch: "agent/growth/issue-${{ env.ISSUE_NUMBER }}"
+          title: "Growth: Fallback-Drafts für #${{ env.ISSUE_NUMBER }}"
           body: |
             Plan: `${{ steps.orch.outputs.plan_path }}`
             Automatischer Fallback, da Growth-Dispatch nicht erkannt wurde.
+            Closes #${{ env.ISSUE_NUMBER }}
           labels: agent:growth, ready-for-review
           signoff: true
           delete-branch: true
@@ -192,9 +213,9 @@ MD
         if: ${{ steps.dispatch.outputs.NEED_FALLBACK_ENGINEER == 'true' }}
         run: |
           mkdir -p reports/agent_runs
-          FILE="reports/agent_runs/orchestrator-fallback-issue-${{ github.event.issue.number }}.md"
+          FILE="reports/agent_runs/orchestrator-fallback-issue-${ISSUE_NUMBER}.md"
           if [ ! -f "$FILE" ]; then
-            echo "# Orchestrator fallback for Issue #${{ github.event.issue.number }}" > "$FILE"
+            echo "# Orchestrator fallback for Issue #${ISSUE_NUMBER}" > "$FILE"
             echo "Plan: ${{ steps.orch.outputs.plan_path }}" >> "$FILE"
           fi
 
@@ -202,12 +223,14 @@ MD
         if: ${{ steps.dispatch.outputs.NEED_FALLBACK_ENGINEER == 'true' }}
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore(fallback): orchestrator PR for issue #${{ github.event.issue.number }}"
-          branch: "agent/fallback/issue-${{ github.event.issue.number }}"
-          title: "Fallback PR für #${{ github.event.issue.number }}"
+          commit-message: "chore(fallback): orchestrator PR for issue #${{ env.ISSUE_NUMBER }}"
+          branch: "agent/fallback/issue-${{ env.ISSUE_NUMBER }}"
+          title: "Fallback PR für #${{ env.ISSUE_NUMBER }}"
           body: |
             Plan: `${{ steps.orch.outputs.plan_path }}`
             Dispatch zu Agenten fehlgeschlagen – Fallback-PR erstellt.
+            Closes #${{ env.ISSUE_NUMBER }}
           labels: agent:engineer, ready-for-review
           signoff: true
           delete-branch: true
+

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,6 +2,7 @@ name: Secret Scan (soft)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch: {}
 permissions:
   contents: read
 jobs:
@@ -12,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: gitleaks (soft)
         run: |
-          set -e
           curl -sSL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_linux_x64.tar.gz \
             | tar -xz && ./gitleaks detect --no-git -v || echo "::warning::gitleaks found issues (soft)"
+

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ Siehe die Unterordner (`.github`, `agents`, `scripts`, `docs`, `kb`, `sales`, `o
 - **Engineer** ergänzt Tests/Policies/Ack und öffnet PR. **Growth** erstellt Drafts/Ack und öffnet PR.
 - Du reviewst & mergest (HITL). Branches werden nach Merge gelöscht.
 - Secret Scan (soft) + bestehende Eval laufen als Checks.
+
+## How to trigger & merge (HITL)
+1. Issue mit Label `task:agent` öffnen oder labeln – oder `workflow_dispatch` im Orchestrator nutzen.
+2. Orchestrator kommentiert den Plan-Link und startet Agenten bzw. erstellt Fallback‑PRs.
+3. PRs prüfen, `eval`‑Status abwarten und manuell mergen. Jeder PR enthält `Closes #<nr>`.
+
+## Troubleshooting
+- **Queued Runs:** Repo‑Minuten aufgebraucht oder Sichtbarkeit zu gering. Manuell via `workflow_dispatch` erneut starten.
+- **Permissions:** Bei Forks `pull_request_target` nutzen. GITHUB_TOKEN muss `contents`/`pull-requests`/`issues` Rechte haben.
+- **Labels fehlen:** Workflow `Sync labels` laufen lassen und sicherstellen, dass Issues das Label `task:agent` tragen.
+

--- a/scripts/orchestrate.py
+++ b/scripts/orchestrate.py
@@ -12,12 +12,19 @@ def main():
         event = json.load(f)
 
     issue = event.get("issue") or {}
-    num   = issue.get("number")
+    if not issue:
+        issue = {
+            "number": os.environ.get("MANUAL_ISSUE_NUMBER"),
+            "title": os.environ.get("MANUAL_ISSUE_TITLE"),
+            "body": os.environ.get("MANUAL_ISSUE_BODY"),
+        }
+    num_raw = issue.get("number")
+    try:
+        num = int(num_raw)
+    except (TypeError, ValueError):
+        print("[orchestrate] ERROR: issue.number not found"); return 0
     title = (issue.get("title") or "").strip()
     body  = (issue.get("body") or "").strip()
-
-    if not isinstance(num, int):
-        print("[orchestrate] ERROR: issue.number not found"); return 0
 
     pathlib.Path("reports/board").mkdir(parents=True, exist_ok=True)
 
@@ -83,3 +90,4 @@ if __name__ == "__main__":
             with open(gh_out, "a", encoding="utf-8") as f:
                 f.write("plan_path=reports/board/plan-error.txt\n")
         raise SystemExit(0)
+


### PR DESCRIPTION
## Summary
- harden orchestrator to handle pre-labeled issues and manual dispatch, logging runs and creating fallback PRs with `Closes #` links
- ensure agent engineer/growth PRs always close their issues and provide deterministic acks
- stabilize CI: explicit `eval` commit status, soft secret scan, label sync fix, plus docs on triggering & troubleshooting

## Testing
- `pytest -q`

## Manual E2E test plan
1. Open a new issue with label `task:agent` (or add the label to an existing issue).  
2. Confirm the Orchestrator comments a plan link and logs dispatch decisions.  
3. Verify Engineer and Growth PRs (or fallback PRs) appear and include `Closes #<nr>`.  
4. Wait for the `eval` check to finish green and merge a PR – the linked issue should auto-close.


------
https://chatgpt.com/codex/tasks/task_e_68c195bb75008329a210e79d86aaa016