### PR TITLE
autofix/final-hardening-and-e2e

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -33,7 +33,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
+              sha: context.payload.pull_request.head.sha,
               state,
               context: 'eval',
               description,

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -18,6 +18,5 @@ jobs:
         with:
           manifest: .github/labels.yml
           repository: ${{ github.repository }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/orchestrate.yml
+++ b/.github/workflows/orchestrate.yml
@@ -21,8 +21,8 @@ permissions:
 
 jobs:
   orchestrate:
-    # Nur laufen, wenn das Issue das Label 'task:agent' trägt (bei dispatch holen wir das Issue vorher)
-    if: ${{ (github.event_name == 'workflow_dispatch') || contains(github.event.issue.labels.*.name, 'task:agent') }}
+    # Läuft auf Issue-Events sowie manuellen dispatches; Label wird später geprüft
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,17 +49,32 @@ jobs:
             core.setOutput('event_path', p)
         id: synth
 
+      - name: Ensure label 'task:agent'
+        id: labelcheck
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const issue_number = context.eventName === 'workflow_dispatch'
+              ? Number(core.getInput('issue_number'))
+              : context.payload.issue.number;
+            const { data: issue } = await github.rest.issues.get({ ...context.repo, issue_number });
+            return (issue.labels || []).some(l => (l.name || l) === 'task:agent') ? 'true' : 'false';
+
       - uses: actions/setup-python@v5
+        if: ${{ steps.labelcheck.outputs.result == 'true' }}
         with:
           python-version: '3.11'
 
       - name: Run orchestrator
+        if: ${{ steps.labelcheck.outputs.result == 'true' }}
         id: orch
         env:
           GITHUB_EVENT_PATH: ${{ github.event_name == 'workflow_dispatch' && steps.synth.outputs.event_path || github.event_path }}
         run: python scripts/orchestrate.py
 
       - name: Commit plan files
+        if: ${{ steps.labelcheck.outputs.result == 'true' }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -68,6 +83,7 @@ jobs:
           git push || true
 
       - name: Comment plan link on issue
+        if: ${{ steps.labelcheck.outputs.result == 'true' }}
         uses: actions/github-script@v7
         env:
           PLAN_PATH: ${{ steps.orch.outputs.plan_path }}
@@ -83,6 +99,7 @@ jobs:
       # Dispatch der Agenten mit Fallback-Erkennung (Engineer & Growth); diese Steps
       # darfst du unverändert lassen, falls du sie schon ähnlich hast — Hauptsache sie laufen.
       - name: Trigger agents (repo_dispatch + workflow_dispatch + detection)
+        if: ${{ steps.labelcheck.outputs.result == 'true' }}
         id: dispatch
         uses: actions/github-script@v7
         env:
@@ -137,9 +154,10 @@ jobs:
 
             let engineerOk = true;
             let growthOk = true;
-            if (fireEngineer) engineerOk = await dispatchAndWait("agent-engineer", ".github/workflows/agent-engineer.yml", 15);
-            if (fireGrowth)   growthOk   = await dispatchAndWait("agent-growth",   ".github/workflows/agent-growth.yml",   15);
+            if (fireEngineer) engineerOk = await dispatchAndWait("agent-engineer", "agent-engineer.yml", 15);
+            if (fireGrowth)   growthOk   = await dispatchAndWait("agent-growth",   "agent-growth.yml",   15);
 
+            core.info(`RUN DETECTED: engineer=${engineerOk} growth=${growthOk}`);
             core.setOutput("NEED_FALLBACK_ENGINEER", engineerOk ? "false" : "true");
             core.setOutput("NEED_FALLBACK_GROWTH",   growthOk   ? "false" : "true");
 
@@ -169,6 +187,7 @@ jobs:
           body: |
             Plan: `${{ steps.orch.outputs.plan_path }}`
             Automatischer Engineer-Fallback, da Agent-Dispatch nicht erkannt wurde.
+            Closes #${{ github.event_name == 'workflow_dispatch' && inputs.issue_number || github.event.issue.number }}
           labels: agent:engineer, ready-for-review
           signoff: true
           delete-branch: true
@@ -216,6 +235,7 @@ MD
           body: |
             Plan: `${{ steps.orch.outputs.plan_path }}`
             Automatischer Growth-Fallback, da Agent-Dispatch nicht erkannt wurde.
+            Closes #${{ github.event_name == 'workflow_dispatch' && inputs.issue_number || github.event.issue.number }}
           labels: agent:growth, ready-for-review
           signoff: true
           delete-branch: true

--- a/.github/workflows/pr-auto-close.yml
+++ b/.github/workflows/pr-auto-close.yml
@@ -2,6 +2,7 @@ name: PR Auto Close Linker
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
+  workflow_dispatch: {}
 permissions:
   pull-requests: write
 jobs:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,5 +14,6 @@ jobs:
       - name: gitleaks (soft)
         run: |
           curl -sSL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_linux_x64.tar.gz \
-            | tar -xz && ./gitleaks detect --no-git -v || echo "::warning::gitleaks found issues (soft)"
+            | tar -xz || true
+          ./gitleaks detect --no-git -v || echo "::warning::gitleaks found issues (soft)"
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ Siehe die Unterordner (`.github`, `agents`, `scripts`, `docs`, `kb`, `sales`, `o
 - **Permissions:** Bei Forks `pull_request_target` nutzen. GITHUB_TOKEN muss `contents`/`pull-requests`/`issues` Rechte haben.
 - **Labels fehlen:** Workflow `Sync labels` laufen lassen und sicherstellen, dass Issues das Label `task:agent` tragen.
 
+## E2E-Testplan
+1. Neues Issue mit Label `task:agent` öffnen (oder vorhandenes labeln).
+2. Orchestrator kommentiert den Plan-Link und triggert Agenten.
+3. Falls kein Agent-Run erkannt wird, erstellt der Orchestrator Fallback-PRs mit Ack-Dateien.
+4. `eval`-Workflow läuft und setzt Commit-Status `eval`.
+5. Nach grünem Status manuell mergen – der PR enthält `Closes #<nr>` und schließt das Issue.
+


### PR DESCRIPTION
## Summary
- make orchestrator react to issue openings and ensure `task:agent` label before dispatching agents or falling back
- add soft secret-scan, stable label-sync, and manual PR body linker
- set explicit `eval` commit status and document end-to-end workflow

## Testing
- `pytest -q`
- `python scripts/check_eval.py`

## E2E Test Plan
1. Create a new issue with `task:agent` label
2. Orchestrator comments plan link and dispatches engineer/growth or opens fallback PRs with acks
3. `eval` workflow reports `eval` commit status
4. Merge PR; issue auto-closes


------
https://chatgpt.com/codex/tasks/task_e_68c19de6fd588329a057d8d7a50430b5